### PR TITLE
Removed invalid arguments to fips_generate

### DIFF
--- a/fips-files/include.cmake
+++ b/fips-files/include.cmake
@@ -8,8 +8,6 @@
 macro(fipsutil_copy yml_file)
     fips_generate(FROM ${yml_file}
         TYPE copy
-        SRC_EXT ".c"
-        HDR_EXT ".h"
         OUT_OF_SOURCE
         ARGS "{ deploy_dir: \"${FIPS_PROJECT_DEPLOY_DIR}\" }")
 endmacro()


### PR DESCRIPTION
Seems like the SRC_EXT and HDR_EXT arguments have been removed in newer versions of fips.