### PR TITLE
fix and full

### DIFF
--- a/fips-files/generators/embed.py
+++ b/fips-files/generators/embed.py
@@ -32,9 +32,11 @@
               { "adca", dump_adca, 842 },
               ...
           };
+      If the option 'list_items: "full"' is provided, the behaviour is simmilar to when
+      'list_items: true' is used, but, the "real" filenames will be used in the list.
 '''
 
-Version = 5
+Version = 6
 
 import sys
 import os.path
@@ -68,7 +70,7 @@ def gen_header(out_hdr, src_dir, files, prefix, list_items) :
                     file_data = src_file.read()
                     file_cname = get_file_cname(file, prefix)
                     file_size = os.path.getsize(file_path)
-                    items[file_cname] = file_size
+                    items[file_cname] = [file, file_size]
                     f.write('unsigned char {}[{}] = {{\n'.format(file_cname, file_size))               
                     num = 0
                     for byte in file_data :
@@ -86,8 +88,12 @@ def gen_header(out_hdr, src_dir, files, prefix, list_items) :
             f.write('typedef struct {{ const char* name; const uint8_t* ptr; int size; }} {}item_t;\n'.format(prefix))
             f.write('#define {}NUM_ITEMS ({})\n'.format(prefix.upper(), len(items)))
             f.write('{}item_t {}items[{}NUM_ITEMS] = {{\n'.format(prefix, prefix, prefix.upper()))
-            for name,size in sorted(items.items()):
-                f.write('{{ "{}", {}, {} }},\n'.format(name[5:], name, size))
+            for name,item in sorted(items.items()):
+                size = item[1]
+                text = name[(len(prefix)):]
+                if 'full' == list_items:
+                    text = item[0]
+                f.write('{{ "{}", {}, {} }},\n'.format(text, name, size))
             f.write('};\n')
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
adds the option to use the "full" filename (without '.' replaced by '_') and fixes a bug where `name[5:]` should have been `name[(len(prefix)):]`