### PR TITLE
Inject the `CurTargetName` in dst dir upon request

### DIFF
--- a/fips-files/generators/copy.py
+++ b/fips-files/generators/copy.py
@@ -25,7 +25,10 @@
     and are copied to the root of the deploy dir (where the executable is
     located).
 
-    To invoke the copy operation as custom build step from CMakeLists.txt files, 
+    In dst_dir, any $TARGET_NAME will be replaced with the current target name
+    as defined in fips_being_*().
+
+    To invoke the copy operation as custom build step from CMakeLists.txt files,
     use the cmake macro from inside a fips_begin_*()/fips_end() block:
 
     fipsutil_copy(yml_file.yml)
@@ -43,15 +46,15 @@ import platform
 
 from shutil import ignore_patterns
 
-#-------------------------------------------------------------------------------
-def copy_files(src_dir, dst_dir, ignore_list, yml):
-    for filename in yml['files']:
-        src = src_dir + filename
-        dst = dst_dir + filename
+# -------------------------------------------------------------------------------
+def copy_files(src_dir, dst_dir, ignore_list, config):
+    for filename in config['files']:
+        src = os.path.join(src_dir, filename)
+        dst = os.path.join(dst_dir, filename)
         print("## cp '{}' => '{}'".format(filename, dst))
-        
+
         if os.path.isdir(src):
-             # if the folder already exists, copytree will unfortunately fail. This is fixed in 3.8+, but for now this is the easiest solution
+            # if the folder already exists, copytree will unfortunately fail. This is fixed in 3.8+, but for now this is the easiest solution
             if os.path.exists(dst):
                 shutil.rmtree(dst)
             try:
@@ -66,10 +69,11 @@ def copy_files(src_dir, dst_dir, ignore_list, yml):
                 shutil.copyfile(src, dst)
             except IOError as err:
                 # show a proper error if file copying fails
-                util.fmtError("Failed to copy file '{}' with '{}'".format(err.filename, err.strerror))
-                
+                util.fmtError("Failed to copy file '{}' with '{}'".format( err.filename, err.strerror))
+
+
 #-------------------------------------------------------------------------------
-def gen_header(out_hdr, yml):
+def gen_header(out_hdr, config):
     with open(out_hdr, 'w') as f:
         f.write('#pragma once\n')
         f.write('//------------------------------------------------------------------------------\n')
@@ -78,53 +82,61 @@ def gen_header(out_hdr, yml):
         f.write('//------------------------------------------------------------------------------\n')
         f.write('// JUST A DUMMY FILE, NOTHING TO SEE HERE\n')
 
+
 #-------------------------------------------------------------------------------
-def check_dirty(src_root_path, input, out_hdr, yml):
+def check_dirty(src_root_path, input, out_hdr, config):
     out_files = [out_hdr]
-    in_files  = [input]
-    if 'files' in yml:
-        for filename in yml['files']:
-            abs_path = os.path.abspath(src_root_path + filename)
+    in_files = [input]
+    if 'files' in config:
+        for filename in config['files']:
+            abs_path = os.path.abspath(os.path.join(src_root_path, filename))
             if os.path.isdir(abs_path):
                 for root, dirs, files in os.walk(abs_path):
                     for file in files:
-                        in_files.append(os.path.abspath(src_root_path + filename + file))
+                        in_files.append(os.path.abspath(os.path.join(src_root_path, filename, file)))
             else:
                 in_files.append(abs_path)
 
     return util.isDirty(Version, in_files, out_files)
 
+
 #-------------------------------------------------------------------------------
 def generate(input, out_src, out_hdr, args):
     with open(input, 'r') as f:
         try:
-            yml = yaml.load(f)
+            config = yaml.load(f)
         except yaml.YAMLError as exc:
             # show a proper error if YAML parsing fails
             util.setErrorLocation(exc.problem_mark.name, exc.problem_mark.line-1)
             util.fmtError('YAML error: {}'.format(exc.problem))
     util.setErrorLocation(input, 1)
-    src_root_path = os.path.dirname(input) + '/'
-    dst_dir = args['deploy_dir'] + '/'
-    if 'options' in yml:
-        if 'src_dir' in yml['options']:
-            src_root_path += yml['options']['src_dir'] + '/'
-        if util.getEnv('target_platform') == 'ios' and 'ios' in yml['options']:
-            if 'dst_dir' in yml['options']['ios']:
-                dst_dir += yml['options']['ios']['dst_dir'] + '/'
-        elif util.getEnv('target_platform') == 'osx' and 'macos' in yml['options']:
-            if 'dst_dir' in yml['options']['macos']:
-                dst_dir += yml['options']['macos']['dst_dir'] + '/'
-        elif 'dst_dir' in yml['options']:
-            dst_dir += yml['options']['dst_dir']
-        del yml['options']
+
+    src_root_path = os.path.dirname(input)
+    dst_dir = args['deploy_dir']
+
+    if 'options' in config:
+        if 'src_dir' in config['options']:
+            src_root_path = os.path.join(src_root_path, config['options']['src_dir'])
+
+        if util.getEnv('target_platform') == 'ios' and 'ios' in config['options'] and 'dst_dir' in config['options']['ios']:
+                dst_dir = os.path.join(dst_dir, config['options']['ios']['dst_dir'])
+
+        elif util.getEnv('target_platform') == 'osx' and 'macos' in config['options'] and 'dst_dir' in config['options']['macos']:
+                dst_dir = os.path.join(dst_dir, config['options']['macos']['dst_dir'])
+
+        elif 'dst_dir' in config['options']:
+            dst_dir = os.path.join(dst_dir, config['options']['dst_dir'])
+
+        del config['options']
+
+    dst_dir = dst_dir.replace('$TARGET_NAME', args['target_name'])
 
     ignore_list = ''
-    if 'ignore' in yml:
-        ignore_list = yml['ignore']
+    if 'ignore' in config:
+        ignore_list = config['ignore']
 
     if not os.path.exists(dst_dir):
         os.makedirs(dst_dir)
-    if check_dirty(src_root_path, input, out_hdr, yml):
-        copy_files(src_root_path, dst_dir, ignore_list, yml)
-        gen_header(out_hdr, yml)
+    if check_dirty(src_root_path, input, out_hdr, config):
+        copy_files(src_root_path, dst_dir, ignore_list, config)
+        gen_header(out_hdr, config)

--- a/fips-files/include.cmake
+++ b/fips-files/include.cmake
@@ -11,7 +11,7 @@ macro(fipsutil_copy yml_file)
         SRC_EXT ".c"
         HDR_EXT ".h"
         OUT_OF_SOURCE
-        ARGS "{ deploy_dir: \"${FIPS_PROJECT_DEPLOY_DIR}\" }")
+        ARGS "{ target_name: \"${CurTargetName}\", deploy_dir: \"${FIPS_PROJECT_DEPLOY_DIR}\" }")
 endmacro()
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
This PR adds a way to specify the current target name in the destination directory.

This change is useful when dealing with sub-directory copy that depends on the app name.
For instance, if wanting to copy files into the `myapp.app` folder on macOS (see https://github.com/floooh/sokol-samples/issues/100) it's necessary currently to use the fixed app name in the path:

```yaml
---
options:
  macos:
      dst_dir: <app_name>.app/Contents/MacOS
files: ["picture.png"]
```

With this change, we could do:

```yaml
---
options:
  macos:
      dst_dir: $TARGET_NAME.app/Contents/MacOS
files: ["picture.png"]
```

and never change it, even if the target name changes.


**Known limitation**: 
- The replacement is on fixed string, so if `$TARGET_NAME` is a valid part of the path, it'll get changed as well. I'm happy to discuss other format, like `{TARGET_NAME}`, ...
- `$TARGET_NAME` is not an environment variable, but rather the cmake `CurTargetName` variable passed from [here](https://github.com/fips-libs/fips-utils/pull/5/files#diff-7f4a86e18f8b61de1304c7ab611fdbb44ad55effe8912ac672d1fcfe3398af22R14) and defined [here](https://github.com/floooh/fips/blob/c9fb4125621067347052dae44dc0fea9585ba3cf/cmake/fips_private.cmake#L23).

---

I also took the opportunity to use `os.path.join` instead of `+` for joining path names, as `+` and `/` is not as portable. cc https://stackoverflow.com/a/13944874

cc https://github.com/floooh/sokol-samples/issues/100