### PR TITLE
fipsutil_copy: changed Android destination dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ For help on generators (aka custom build jobs) read on:
 
 Those are usually available through cmake macros:
 
-- [fipsutil_copy()](fips-files/generators/copy.py): copy files from project directory to deployment directory
+- [fipsutil_copy()](fips-files/generators/copy.py): copy files from project directory to deployment directory. On android files are copied to assets dir of android project (and packed to apk).
 - [fipsutil_embed()](fips-files/generators/embed.py): embed binary files into C headers
 
 For usage examples, see the [sokol-samples](https://github.com/floooh/sokol-samples/)

--- a/fips-files/include.cmake
+++ b/fips-files/include.cmake
@@ -6,12 +6,18 @@
 #   Also see fips-files/generators/copy.py
 #
 macro(fipsutil_copy yml_file)
+    if (FIPS_ANDROID)
+        set(DEPLOY_DIR ${CMAKE_CURRENT_BINARY_DIR}/android/${CurTargetName}/assets)
+    else()
+        set(DEPLOY_DIR ${FIPS_PROJECT_DEPLOY_DIR})
+    endif()
+
     fips_generate(FROM ${yml_file}
         TYPE copy
         SRC_EXT ".c"
         HDR_EXT ".h"
         OUT_OF_SOURCE
-        ARGS "{ target_name: \"${CurTargetName}\", deploy_dir: \"${FIPS_PROJECT_DEPLOY_DIR}\" }")
+        ARGS "{ target_name: \"${CurTargetName}\", deploy_dir: \"${DEPLOY_DIR}\" }")
 endmacro()
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
In a case of Android, copy resources to "assets" folder in Android project. (this is in fips-build directory). These resources are later packed into apk.